### PR TITLE
Update to work with Visual Studio

### DIFF
--- a/CleanArchitecture.Templates.csproj
+++ b/CleanArchitecture.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.3.0</PackageVersion>
+    <PackageVersion>1.3.1</PackageVersion>
     <PackageId>CleanArchitecture.Templates</PackageId>
     <Title>Clean Architecture Templates</Title>
     <Authors>Casey Crouse</Authors>

--- a/templates/ca-sln-sql/.template.config/template.json
+++ b/templates/ca-sln-sql/.template.config/template.json
@@ -62,7 +62,67 @@
   "primaryOutputs": [
     {
       "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
-      "path": "ComponentsWebAssembly-CSharp.sln"
+      "path": "src/Application/Application.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "src/Common/Common.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "src/Domain/Domain.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "src/Events/Events.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "src/Infrastructure/Infrastructure.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "src/Presistence.Sql/Presistence.Sql.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "src/Presentation.API/Presentation.API.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "src/Presentation.AzureFunction/Presentation.AzureFunction.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "src/Presentation.Console/Presentation.Console.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "tst/Business.Tests/Business.Tests.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "tst/Common.Tests/Common.Tests.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "tst/Infrastructure.Tests/Infrastructure.Tests.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "tst/Mapping.Tests/Mapping.Tests.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "tst/Persistence.Tests/Persistence.Tests.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "tst/Presentation.API.Tests/Presentation.API.Tests.csproj"
+    },
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "tst/Presentation.Console.Tests.Tests/Presentation.Console.Tests.csproj"
     }
   ],
   "sources": [

--- a/templates/ca-sln-sql/.template.config/template.json
+++ b/templates/ca-sln-sql/.template.config/template.json
@@ -1,11 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Casey Crouse",
-  "classifications": [
-    "Web",
-    "Console",
-    "AzureFunction"
-  ],
+  "classifications": ["Web", "Console", "AzureFunction"],
   "name": "Clean Architecture Solution Template",
   "description": "Creates a flexible solution with EntityFrameworkCore based on Domain Driven Design using the Mediator and Clean Architecture patterns.",
   "identity": "CleanArchitecture.Solution.Template.Sql",
@@ -13,11 +9,12 @@
   "shortName": "ca-sln-sql",
   "tags": {
     "language": "C#",
-    "type": "solution",
+    "type": "project",
     "runtime": "dotnet core",
     "runtime_version": "3",
     "patterns": ["Mediator", "DDD", "Clean Architecture"]
   },
+  "defaultName": "WebApplication1",
   "sourceName": "App._APP_NAME_",
   "preferNameDirectory": true,
   "symbols": {
@@ -61,5 +58,25 @@
       "replaces": "_GIT_IGNORE_",
       "fileRename": "_GIT_IGNORE_"
     }
-  }
+  },
+  "primaryOutputs": [
+    {
+      "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+      "path": "ComponentsWebAssembly-CSharp.sln"
+    }
+  ],
+  "sources": [
+    {
+      "source": "./",
+      "target": "./",
+      "modifiers": [
+        {
+          "condition": "(Hosted && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+          "exclude": [
+          "*.sln"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/templates/ca-sln/.template.config/template.json
+++ b/templates/ca-sln/.template.config/template.json
@@ -25,19 +25,46 @@
       "type": "parameter",
       "datatype": "int",
       "isRequired": false,
-      "description": "A non-secure port number. (e.g. 30365)",
-      "replaces": "_HTTP_PORT_",
-      "fileRename": "_HTTP_PORT_",
-      "defaultValue": "5000"
+      "description": "A non-secure port number. (e.g. 30365)"
     },
+    "generated-port": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "port-final": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "port",
+        "fallbackVariableName": "generated-port"
+      },
+      "replaces": "_HTTP_PORT_",
+      "fileRename": "_HTTP_PORT_"
+    },
+
     "secure-port": {
       "type": "parameter",
       "datatype": "int",
       "isRequired": false,
-      "description": "A secure port number. (e.g. 44395)",
+      "description": "A secure port number. (e.g. 44395)"
+    },
+    "generated-secure-port": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
+    },
+    "secure-port-final": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "secure-port",
+        "fallbackVariableName": "generated-secure-port"
+      },
       "replaces": "_HTTPS_PORT_",
-      "fileRename": "_HTTPS_PORT_",
-      "defaultValue": "45501"
+      "fileRename": "_HTTPS_PORT_"
     },
     "git-ignore": {
       "type": "parameter",

--- a/templates/ca-sln/.template.config/template.json
+++ b/templates/ca-sln/.template.config/template.json
@@ -13,7 +13,7 @@
   "shortName": "ca-sln",
   "tags": {
     "language": "C#",
-    "type": "solution",
+    "type": "project",
     "runtime": "dotnet core",
     "runtime_version": "3",
     "patterns": ["Mediator", "DDD", "Clean Architecture"]
@@ -24,7 +24,7 @@
     "app-name": {
       "type": "parameter",
       "datatype": "text",
-      "isRequired": true,
+      "isRequired": false,
       "description": "The name of the application.",
       "replaces": "_APP_NAME_",
       "fileRename": "_APP_NAME_"
@@ -39,18 +39,20 @@
     "port": {
       "type": "parameter",
       "datatype": "int",
-      "isRequired": true,
+      "isRequired": false,
       "description": "A non-secure port number. (e.g. 30365)",
       "replaces": "_HTTP_PORT_",
-      "fileRename": "_HTTP_PORT_"
+      "fileRename": "_HTTP_PORT_",
+      "defaultValue": "5000"
     },
     "secure-port": {
       "type": "parameter",
       "datatype": "int",
-      "isRequired": true,
+      "isRequired": false,
       "description": "A secure port number. (e.g. 44395)",
       "replaces": "_HTTPS_PORT_",
-      "fileRename": "_HTTPS_PORT_"
+      "fileRename": "_HTTPS_PORT_",
+      "defaultValue": "45501"
     },
     "git-ignore": {
       "type": "parameter",

--- a/templates/ca-sln/.template.config/template.json
+++ b/templates/ca-sln/.template.config/template.json
@@ -18,24 +18,9 @@
     "runtime_version": "3",
     "patterns": ["Mediator", "DDD", "Clean Architecture"]
   },
-  "sourceName": "App._APP_NAME_",
+  "sourceName": "_APP_NAME_",
   "preferNameDirectory": true,
   "symbols": {
-    "app-name": {
-      "type": "parameter",
-      "datatype": "text",
-      "isRequired": false,
-      "description": "The name of the application.",
-      "replaces": "_APP_NAME_",
-      "fileRename": "_APP_NAME_"
-    },
-    "app-name-lower": {
-      "type": "generated",
-      "generator": "casing",
-      "parameters": { "source": "app-name", "toLower": true },
-      "replaces": "_APP_NAME_LOWER_",
-      "fileRename": "_APP_NAME_LOWER_"
-    },
     "port": {
       "type": "parameter",
       "datatype": "int",

--- a/templates/ca-sln/.template.config/vs-2017.3.host.json
+++ b/templates/ca-sln/.template.config/vs-2017.3.host.json
@@ -1,18 +1,3 @@
 {
-  "$schema": "http://json.schemastore.org/vs-2017.3.host",
-  "symbolInfo": [
-    {
-       "id": "app-name",
-       "name": {
-          "text": "Application Name"
-       },
-       "isVisible": true,
-       "defaultValue": "DefaultAppName"
-    },
-    {
-        "id": "app-name-lower",
-        "isVisible": true,
-        "defaultValue":"defaultappname"
-     }
- ]
+  "$schema": "http://json.schemastore.org/vs-2017.3.host"
 }

--- a/templates/ca-sln/.template.config/vs-2017.3.host.json
+++ b/templates/ca-sln/.template.config/vs-2017.3.host.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json.schemastore.org/vs-2017.3.host",
+  "symbolInfo": [
+    {
+       "id": "app-name",
+       "name": {
+          "text": "Application Name"
+       },
+       "isVisible": true,
+       "defaultValue": "DefaultAppName"
+    },
+    {
+        "id": "app-name-lower",
+        "isVisible": true,
+        "defaultValue":"defaultappname"
+     }
+ ]
+}

--- a/tools/New-SolutionTest.ps1
+++ b/tools/New-SolutionTest.ps1
@@ -1,6 +1,6 @@
 
 $defaultLocation = Join-Path -Path $PSScriptRoot -ChildPath ".."
-Set-Location $defaultLocation
+Push-Location $defaultLocation
 Get-ChildItem -Path . -Recurse -Filter *.nupkg -ErrorAction SilentlyContinue | ForEach-Object { $_ | Remove-Item -Force -ErrorAction SilentlyContinue }
 
 dotnet pack 'CleanArchitecture.Templates.csproj'
@@ -22,4 +22,4 @@ dotnet restore "$solutionName/$solutionName.sln"
 dotnet build "$solutionName/$solutionName.sln" -c Release --no-restore
 $testProjects = Get-ChildItem -Path . -Recurse -Filter *Tests.csproj -ErrorAction SilentlyContinue
 $testProjects | ForEach-Object { dotnet test "$($_.FullName)" --no-restore --no-build --configuration Release }
-Set-Location ../.. | Out-Null
+Pop-Location


### PR DESCRIPTION
I've made some changes to make the app work with Visual Studio. It's still a work in progress. I've only addressed one of the two templates thus far.

I removed the app-name and app-name-lower parameters. The `sourceName` property can do that for us. See my [write up about sourceName](https://devblogs.microsoft.com/dotnet/how-to-create-your-own-templates-for-dotnet-new/#how-to-create-a-basic-template). I didn't see any usage of app-name-lower in either the code, or the file names. `sourceName` can take care of that for us as well. Just use the lower version of the value for `sourceName` and the correct format should be auto selected when the template is executed.

I also updated the port symbols. If a port is not specified, one will be generated, and that allows those params to be optional.

I still need to do some work to make the parameters appear in VS.